### PR TITLE
Cherry-pick fix to mrb_protect_atexit prototype

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -177,7 +177,7 @@ mrb_free_context(mrb_state *mrb, struct mrb_context *c)
   mrb_free(mrb, c);
 }
 
-int mrb_protect_atexit(mrb_state *mrb);
+void mrb_protect_atexit(mrb_state *mrb);
 
   MRB_API void
 mrb_close(mrb_state *mrb)


### PR DESCRIPTION
Cherry picks https://github.com/mruby/mruby/commit/7fe6f3976eca19a86fe533deb4c60b31cd80a236 from upstream which fixes the upstream bug https://github.com/mruby/mruby/pull/5411.

I ran into this when trying to update the <https://artichoke.run> Wasm artifact to the most recent trunk of artichoke/artichoke.

The emscripten linker is stricter than clang and fails to link when there is a prototype mismatch. I've ran into similar breakages before in the Artichoke mruby-sys C extension: https://github.com/artichoke/artichoke/pull/412. See also https://github.com/artichoke/artichoke/issues/413.